### PR TITLE
5 feature add tag filtering on projects page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "simple-api-test",
+	"name": "awesome-svelte-and-d3-website",
 	"version": "0.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "simple-api-test",
+			"name": "awesome-svelte-and-d3-website",
 			"version": "0.0.1",
 			"dependencies": {
 				"@fontsource/clear-sans": "^4.5.3",
@@ -28,6 +28,7 @@
 				"svelte-hamburgers": "^4.0.1",
 				"svelte-mount": "^1.0.2",
 				"svelte-preprocess": "^4.10.7",
+				"svelte-tags-input": "^3.0.0",
 				"vite": "^3.1.0"
 			}
 		},
@@ -2985,6 +2986,12 @@
 				"sourcemap-codec": "^1.4.8"
 			}
 		},
+		"node_modules/svelte-tags-input": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/svelte-tags-input/-/svelte-tags-input-3.0.0.tgz",
+			"integrity": "sha512-6BvVyzP2aQ1G+twW1H30wKFQDQxQuupBzMXxQ46inPcNbkl3oTSIMqptPqzslH3ytyOepgv6Q6k5wsgj4GNesA==",
+			"dev": true
+		},
 		"node_modules/tar": {
 			"version": "6.1.11",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
@@ -5284,6 +5291,12 @@
 					}
 				}
 			}
+		},
+		"svelte-tags-input": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/svelte-tags-input/-/svelte-tags-input-3.0.0.tgz",
+			"integrity": "sha512-6BvVyzP2aQ1G+twW1H30wKFQDQxQuupBzMXxQ46inPcNbkl3oTSIMqptPqzslH3ytyOepgv6Q6k5wsgj4GNesA==",
+			"dev": true
 		},
 		"tar": {
 			"version": "6.1.11",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"svelte-hamburgers": "^4.0.1",
 		"svelte-mount": "^1.0.2",
 		"svelte-preprocess": "^4.10.7",
+		"svelte-tags-input": "^3.0.0",
 		"vite": "^3.1.0"
 	},
 	"type": "module",

--- a/src/lib/components/Accordion.svelte
+++ b/src/lib/components/Accordion.svelte
@@ -1,0 +1,50 @@
+<script>
+	// what is displayed initially next to the triangle symbol
+	export let summary = 'Toggle me';
+</script>
+
+<details class="accordion">
+	<summary>
+		<b>{summary}</b>
+	</summary>
+
+	<div class="details flow">
+		<slot />
+	</div>
+</details>
+
+<style>
+	details {
+		--flow-space: var(--space-s);
+		padding: var(--space-s);
+		margin: var(--space-xs) 0;
+		background-color: var(--surface0-light);
+		font-family: var(--accentFont);
+	}
+	/* # The Rotating Marker # */
+	/* h/t https://codepen.io/redesigned/pen/wvoEvqG */
+	summary {
+		display: block;
+		position: relative;
+		cursor: pointer;
+		padding: 1rem 2rem;
+		padding-left: 2.9rem;
+	}
+	/* # The Rotating Marker # */
+	details summary::-webkit-details-marker {
+		display: none;
+	}
+	summary::before {
+		content: '▶';
+		position: absolute;
+		top: 1rem;
+		left: 0.8rem;
+		transform: rotate(0);
+		transform-origin: center;
+		transition: 0.25s transform ease;
+	}
+	details[open] > summary:before {
+		transform: rotate(90deg);
+		transition: 0.25s transform ease;
+	}
+</style>

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -1,4 +1,5 @@
 <script>
+	import Pill from '$lib/components/Pill.svelte';
 	import { marked } from 'marked';
 	export let url = '';
 	export let name = '';
@@ -13,18 +14,15 @@
 	export let taglist;
 
 	tags.sort(); // sort alphabetically
+	let show = true; // helper to toggle visibility
 
-	let show = true;
-
+	// reactively toggle visibility
+	// if all filter-tags match given project-tags
 	$: {
 		if (taglist) {
 			show = taglist.every((r) => tags.includes(r));
 		}
 	}
-
-	$: console.log({ taglist, show });
-
-	// TODO: open more info about each project in a modal via https://svelte.dev/repl/629f732d77fb48f79826b58b6ec4137f?version=3.37.0 ?
 
 	// TODO: add "&" before last author (and between 1 & 2 if only 2?)
 	if (authors.length > 1) {
@@ -50,15 +48,17 @@
 		</div>
 
 		<div class="tags flow">
-			Tags:
 			{#each tags as tag}
-				<div class="pill tag">#{tag}</div>
+				<Pill on:addTag {tag} />
 			{/each}
 		</div>
 	</article>
 {/if}
 
 <style lang="scss">
+	img {
+		box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+	}
 	.card {
 		--radius-card: 0.1rem;
 		font-family: var(--accentFont);

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -10,8 +10,19 @@
 	export let demo = '';
 	export let sourceCode = '';
 	export let tags = '';
+	export let taglist;
 
 	tags.sort(); // sort alphabetically
+
+	let show = true;
+
+	$: {
+		if (taglist) {
+			show = taglist.every((r) => tags.includes(r));
+		}
+	}
+
+	$: console.log({ taglist, show });
 
 	// TODO: open more info about each project in a modal via https://svelte.dev/repl/629f732d77fb48f79826b58b6ec4137f?version=3.37.0 ?
 
@@ -21,29 +32,31 @@
 	}
 </script>
 
-<article class="card flow">
-	<div class="title">
-		<strong>{name}</strong>
-	</div>
-	<img src={url} alt={name} />
-	<p class="authors">by {authors}</p>
+{#if show}
+	<article class="card flow">
+		<div class="title">
+			<strong>{name}</strong>
+		</div>
+		<img src={url} alt={name} />
+		<p class="authors">by {authors}</p>
 
-	<p class="description">{@html marked(description)}</p>
+		<p class="description">{@html marked(description)}</p>
 
-	<div class="details grid flow">
-		<a class="button" target="_blank" rel="noopener noreferrer" href={demo}>Live Site &nearr;</a>
-		<a class="button" target="_blank" rel="noopener noreferrer" href={sourceCode}
-			>Source Code &nearr;
-		</a>
-	</div>
+		<div class="details grid flow">
+			<a class="button" target="_blank" rel="noopener noreferrer" href={demo}>Live Site &nearr;</a>
+			<a class="button" target="_blank" rel="noopener noreferrer" href={sourceCode}
+				>Source Code &nearr;
+			</a>
+		</div>
 
-	<div class="tags flow">
-		Tags:
-		{#each tags as tag}
-			<div class="pill tag">#{tag}</div>
-		{/each}
-	</div>
-</article>
+		<div class="tags flow">
+			Tags:
+			{#each tags as tag}
+				<div class="pill tag">#{tag}</div>
+			{/each}
+		</div>
+	</article>
+{/if}
 
 <style lang="scss">
 	.card {

--- a/src/lib/components/Pill.svelte
+++ b/src/lib/components/Pill.svelte
@@ -1,0 +1,23 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+	const dispatch = createEventDispatcher();
+
+	export let tag = '';
+
+	function addTag() {
+		dispatch('addTag', {
+			text: tag
+		});
+	}
+</script>
+
+<button class="pill tag" on:click={addTag} {tag}>
+	{tag}
+</button>
+
+<style>
+	button {
+		background-color: inherit;
+		margin: var(--space-3xs);
+	}
+</style>

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,6 +1,111 @@
 <script>
-	/** @type {import('./$types').PageData} */
-	export let data;
+	import { getContextClient, gql, queryStore } from '@urql/svelte';
+	import ProjectCard from '$lib/components/Card.svelte';
+	import Tags from 'svelte-tags-input';
+
+	// see https://dev.to/tiim/sveltekit-server-side-rendering-ssr-with-urqlsvelte-534k
+	const projectsQueryStore = queryStore({
+		client: getContextClient(),
+		query: gql`
+			{
+				projects {
+					name
+					authors
+					slug
+					description
+					tags
+					demo
+					sourceCode
+					image {
+						url(transformation: { image: { resize: { width: 800, height: 800, fit: crop } } })
+					}
+				}
+			}
+		`
+	});
+
+	// $: tags_all = [...new Set($projectsQueryStore.data.projects.map((item) => item.tags))].reduce(
+	// 	(accumulator, currentValue) => accumulator.concat(currentValue),
+	// 	[]
+	// );
+
+	// //$: console.log(tags_all);
+
+	// let tags_all_lower = [];
+
+	// $: {
+	// 	tags_all.forEach((element) => {
+	// 		tags_all_lower.push(element.toLowerCase());
+	// 	});
+	// 	// for (const tag of tags_all) {
+	// 	// 	console.log(tag.toLowerCase());
+	// 	// 	tags_all_lower.push(tag.toLowerCase());
+	// 	// }
+	// }
+
+	// $: console.log(tags_all_lower);
+
+	// $: tags_unique = [...new Set(tags_all_lower)];
+
+	// $: console.log(tags_unique);
+
+	// If on:tags is defined
+	let taglist = '';
+
+	function handleTags(event) {
+		taglist = event.detail.tags;
+	}
+
+	let tags_unique = [
+		'scrollytelling',
+		'scatter',
+		'line',
+		'bar',
+		'map',
+		'bump',
+		'sankey',
+		'machineLearning',
+		'statistics',
+		'interactive',
+		'food'
+	];
 </script>
 
+<svelte:head>
+	<title>Awesome Svelte & D3 | Projects</title>
+</svelte:head>
+
 <h2>Projects in the wild</h2>
+
+<h4>Use tags to filter out specific projects:</h4>
+<Tags
+	on:tags={handleTags}
+	placeholder={'Enter a tag...'}
+	autoComplete={tags_unique}
+	name={'selected-tags'}
+	id={'tag-selector'}
+/>
+
+<div class="container grid">
+	{#if $projectsQueryStore.fetching}
+		<p>Loading...</p>
+	{:else if $projectsQueryStore.error}
+		<p>Oopsie! {$projectsQueryStore.error.message}</p>
+	{:else}
+		{#each $projectsQueryStore.data.projects as p}
+			{#key taglist}
+				<ProjectCard
+					name={p.name}
+					authors={p.authors}
+					description={p.description}
+					url={p.image[0].url}
+					slug={p.slug}
+					demo={p.demo}
+					sourceCode={p.sourceCode}
+					tags={p.tags}
+					{taglist}
+				/>
+			{/key}
+		{/each}
+	{/if}
+</div>

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -2,6 +2,7 @@
 	import { getContextClient, gql, queryStore } from '@urql/svelte';
 	import ProjectCard from '$lib/components/Card.svelte';
 	import Tags from 'svelte-tags-input';
+	import Accordion from '$lib/components/Accordion.svelte';
 
 	const projectsQueryStore = queryStore({
 		client: getContextClient(),
@@ -29,8 +30,12 @@
 
 	// this will add a tag to the filter-list when clicked on in the cards
 	function addTag(event) {
-		taglist.push(event.detail.text);
-		taglist = taglist;
+		var newTag = event.detail.text;
+		// but add the tag only if it is not already included
+		if (!taglist.includes(newTag)) {
+			taglist.push(newTag);
+			taglist = taglist;
+		}
 	}
 
 	// this is the native function provided by svelte-tags-input
@@ -61,22 +66,25 @@
 
 <h2>Projects in the wild</h2>
 
-<h4>Use tags to filter out specific projects:</h4>
-<p class="instruction">
-	You can either start typing and use autocomplete or click on the little tags within each
-	Project-Card.
-</p>
+<Accordion summary="Filter items">
+	<h4>Use tags to filter out specific projects:</h4>
+	<p class="instruction">
+		You can either start typing and use autocomplete or click on the tags within each Project-Card.
+	</p>
 
-<div class="tag-wrapper">
-	<Tags
-		on:tags={handleTags}
-		placeholder={'Enter a tag...'}
-		autoComplete={tags_unique}
-		name={'selected-tags'}
-		id={'tag-selector'}
-		tags={taglist}
-	/>
-</div>
+	<div class="tag-wrapper">
+		<Tags
+			on:tags={handleTags}
+			placeholder={'Enter a tag...'}
+			autoComplete={tags_unique}
+			onlyAutocomplete={true}
+			onlyUnique={true}
+			name={'selected-tags'}
+			id={'tag-selector'}
+			tags={taglist}
+		/>
+	</div>
+</Accordion>
 
 <div class="container grid">
 	{#if $projectsQueryStore.fetching}

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -3,7 +3,6 @@
 	import ProjectCard from '$lib/components/Card.svelte';
 	import Tags from 'svelte-tags-input';
 
-	// see https://dev.to/tiim/sveltekit-server-side-rendering-ssr-with-urqlsvelte-534k
 	const projectsQueryStore = queryStore({
 		client: getContextClient(),
 		query: gql`
@@ -24,38 +23,23 @@
 		`
 	});
 
-	// $: tags_all = [...new Set($projectsQueryStore.data.projects.map((item) => item.tags))].reduce(
-	// 	(accumulator, currentValue) => accumulator.concat(currentValue),
-	// 	[]
-	// );
+	// start with empty taglist
+	// this is where tags will be added
+	let taglist = [];
 
-	// //$: console.log(tags_all);
+	// this will add a tag to the filter-list when clicked on in the cards
+	function addTag(event) {
+		taglist.push(event.detail.text);
+		taglist = taglist;
+	}
 
-	// let tags_all_lower = [];
-
-	// $: {
-	// 	tags_all.forEach((element) => {
-	// 		tags_all_lower.push(element.toLowerCase());
-	// 	});
-	// 	// for (const tag of tags_all) {
-	// 	// 	console.log(tag.toLowerCase());
-	// 	// 	tags_all_lower.push(tag.toLowerCase());
-	// 	// }
-	// }
-
-	// $: console.log(tags_all_lower);
-
-	// $: tags_unique = [...new Set(tags_all_lower)];
-
-	// $: console.log(tags_unique);
-
-	// If on:tags is defined
-	let taglist = '';
-
+	// this is the native function provided by svelte-tags-input
 	function handleTags(event) {
 		taglist = event.detail.tags;
 	}
 
+	// WIP: a list of all (?) tags
+	// used for autocomplete!
 	let tags_unique = [
 		'scrollytelling',
 		'scatter',
@@ -78,13 +62,21 @@
 <h2>Projects in the wild</h2>
 
 <h4>Use tags to filter out specific projects:</h4>
-<Tags
-	on:tags={handleTags}
-	placeholder={'Enter a tag...'}
-	autoComplete={tags_unique}
-	name={'selected-tags'}
-	id={'tag-selector'}
-/>
+<p class="instruction">
+	You can either start typing and use autocomplete or click on the little tags within each
+	Project-Card.
+</p>
+
+<div class="tag-wrapper">
+	<Tags
+		on:tags={handleTags}
+		placeholder={'Enter a tag...'}
+		autoComplete={tags_unique}
+		name={'selected-tags'}
+		id={'tag-selector'}
+		tags={taglist}
+	/>
+</div>
 
 <div class="container grid">
 	{#if $projectsQueryStore.fetching}
@@ -95,6 +87,7 @@
 		{#each $projectsQueryStore.data.projects as p}
 			{#key taglist}
 				<ProjectCard
+					on:addTag={addTag}
 					name={p.name}
 					authors={p.authors}
 					description={p.description}
@@ -109,3 +102,26 @@
 		{/each}
 	{/if}
 </div>
+
+<style lang="scss">
+	.instruction {
+		font-size: var(--step-0);
+	}
+	.tag-wrapper :global(.svelte-tags-input) {
+		font-family: inherit;
+		font-size: var(--step-0);
+	}
+
+	.tag-wrapper :global(.svelte-tags-input-matchs) {
+		font-family: inherit;
+		font-size: var(--step-0);
+	}
+	.tag-wrapper :global(.svelte-tags-input-tag) {
+		font-family: inherit;
+		font-size: var(--step-0);
+	}
+
+	.tag-wrapper :global(.svelte-tags-input-layout) {
+		font-family: inherit;
+	}
+</style>


### PR DESCRIPTION
This adds a new feature to the projects page.

With this filter module users can:
- filter by typing in tags (autocomplete will suggest possible tags)
- click on tags in project cards (these will then be added in the tag-list)

The displayed projects update immediately when tags are added or removed.

Invalid tags are not possible (you can only enter tags that are in a predefined list).
This leads to a change in how we manage the information in the CMS.
There should be a list of unique tags in the CMS that the tags for each project can be selected from (I started doing this now).
The same list must be fed into the filter-module.

I introduced a new component that can be used to optionally show/hide content and put the filter-module in it.
That way, users get to see the projects right away and can use the filter if they want to by toggling it open.
